### PR TITLE
READMEを英日併記に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,90 @@
-# はじめまして 👋
-サーバーサイドエンジニアです。Javaをメインで経験してきました。  
-  
-  
-# 氏名
-水上 皓登(みずかみ　ひろと)
+# Hello 👋 / はじめまして 👋
 
-# 生年月日
-1992年 02月 04日
+I'm a server-side engineer with a Java-focused background.
 
-# 職歴
+サーバーサイドエンジニアです。Javaをメインで経験してきました。
+
+
+# Name / 氏名
+Hiroto Mizukami (水上 皓登 / みずかみ　ひろと)
+
+# Date of Birth / 生年月日
+February 4, 1992 / 1992年 02月 04日
+
+# Career / 職歴
+
+I've been working as an engineer since 2014 — currently in my 12th year.
 
 エンジニアとしては、2014年から働いており、エンジニア歴は12年目です。
 
-## 本業
-- 2014/04～2019/01
-    - 株式会社ISTソフトウェア
+## Full-time / 本業
+- 2014/04 – 2019/01
+    - IST Software Co., Ltd. / 株式会社ISTソフトウェア
+        - Second-tier SIer. Worked on systems for government agencies.
+          Experienced the full lifecycle from requirements to release (no operations).
+          Did team development as well as solo on-site assignments at client offices.
         - 2次受けSIer。  
         官公庁向けシステムに携わってきた。  
         要件定義からリリースまで一気通貫で開発した経験あり。ただし、運用は行ったことが無い。  
         チームでの開発、一人での客先常駐等の様々な経験した。
-- 2019/02～2023/10
-    - ソフトバンク株式会社
+- 2019/02 – 2023/10
+    - SoftBank Corp. / ソフトバンク株式会社
+        - Worked in an Agile environment. No formal team-lead role, but led the team in practice
+          by sharing knowledge and consistently out-implementing peers.
+          Tech: Spring Boot, Python, and others.
         - アジャイルを経験。  
         アジャイルなのでチームリーダーという明確な役割はない。  
         しかし、技術を伝えたり、他人よりも多く実装する等でチームメンバーを引っ張ってきた。  
         利用技術: Spring Boot、Python 他
-- 2023/11～現在
+- 2023/11 – Present / 現在
     - KAKEAI, Inc.
+        - 2023/11 – 2025/04 Technical Lead (Tokyo, Japan / on-site)
+          Tech: FastAPI, Ruby on Rails, and others.
         - 2023/11～2025/04 テクニカルリード（日本 東京都・オンサイト）  
         利用技術: FastAPI、Ruby on Rails 他
+        - 2025/05 – Present: Chief Technology Officer (CTO / office-based)
         - 2025/05～現在 最高技術責任者（CTO・オフィス勤務）
+        - 2026/01 – Present: Technical Lead
         - 2026/01～現在 テクニカルリード
-        
-## 副業 
-- 2021/07～2021/09
-  - 株式会社コミチ
+
+## Side jobs / 副業
+- 2021/07 – 2021/09
+  - Comichi Co., Ltd. / 株式会社コミチ
+    - Implemented markup based on Figma designs.
     - Figmaで指定されたデザインを元にマークアップしました。
-- 2020/08～2022/04
-  - 株式会社チーム・ゼロイチ
+- 2020/08 – 2022/04
+  - Team Zero-Ichi Co., Ltd. / 株式会社チーム・ゼロイチ
 
 <!--
 -->
 
-# 出身大学
-東京農業大学
+# University / 出身大学
+Tokyo University of Agriculture / 東京農業大学
 
-# 言語
-|言語|年数|
+# Languages / 言語
+| Language / 言語 | Years / 年数 |
 |---|---|
-|Java|7.5年|
-|Python|3.5年|
-|FastAPI|1.5年|
-|VB6|1.5年|
-|VB.NET|1.5年|
-|JQuery|3年|
-|Ruby|2年|
-|Ruby|2年|
-|vue.js|0.5カ月|
-|React.js|0.5カ月|  
+| Java | 7.5 years / 年 |
+| Python | 3.5 years / 年 |
+| FastAPI | 1.5 years / 年 |
+| VB6 | 1.5 years / 年 |
+| VB.NET | 1.5 years / 年 |
+| jQuery | 3 years / 年 |
+| Ruby | 2 years / 年 |
+| Vue.js | 0.5 month / カ月 |
+| React.js | 0.5 month / カ月 |
 
-# 得意
+# Strengths in Practice / 得意
+
+I like reducing the total person-hours across a team.
+If we have 100 people × 100 hours = 10,000 hours,
+I'd rather make it 1 person × 110 hours + 99 people × 99 hours = 9,911 hours.
+
+I organize information and document as much as possible so the same mistake doesn't happen twice.
+At minimum, I leave notes in a form *I* can search, which lowers the cost of handoffs and lookups for others.
+Having me on a project means information gets organized — it makes me easy to work with.
+I revisit my own thinking many times, so my overall execution speed is fast.
+
 総合的な工数を削減するのが好きです。  
 100人 * 100時間 = 10,000 時間  
 の状況であれば、  
@@ -73,51 +98,61 @@
   
 何度も考えを反芻するので、総合的な行動速度は早いです。  
 
-# 強み
+# Strengths / 強み
+
+I can repeat the same task many times without getting bored.
+Even in difficult situations, I find a way to enjoy the present and think about how to improve it.
+
 飽きもせず、何度も繰り返せるできることが強みです。
   
 また、困難な状態でも現状を楽しみ、どうやって改善していくかを考えていくことができるのが強みです。
 
-# ブログ
+# Blog / ブログ
 https://nainaistar.hatenablog.com/
 
-# 登壇資料（SpeakerDeck）
+# Speaker Deck / 登壇資料（SpeakerDeck）
 https://speakerdeck.com/hirotokirimaru
   
-# LaprasのScore
+# Lapras Score / LaprasのScore
 ![lapras_score](https://media.lapras.com/media/public_setting/JFCUKEW/38aec794daf84384becb29fdc0104733.png)
 
 <!-- 一旦 公式側は停止 -->
 <!--START_SECTION:lapras-card-->
 <!--END_SECTION:lapras-card-->
 
-# repository
+# Repository
 ![kirimaru's github stats](https://github-readme-stats.vercel.app/api?username=hirotoKirimaru&show_icons=true)
 
-# ポートフォリオ
+# Portfolio / ポートフォリオ
 http://hirotokirimaru.github.io
 
-# クリフトンストレングス（ストレングスファインダー）
-2021年1月2日実施
-![クリフトンストレングス](https://github.com/hirotoKirimaru/hirotoKirimaru/blob/master/cliftonstrengths_20200102.pdf)
+# CliftonStrengths / クリフトンストレングス（ストレングスファインダー）
+Taken on January 2, 2021 / 2021年1月2日実施
+![CliftonStrengths](https://github.com/hirotoKirimaru/hirotoKirimaru/blob/master/cliftonstrengths_20200102.pdf)
 
 # LeetCode
 https://leetcode.com/hirotoKirimaru/
 
-# 制作物
+# Works / 制作物
 
 - https://i-am-eternal-17.vercel.app/
-- https://trpg-charactors.firebaseapp.com/ 
+- https://trpg-charactors.firebaseapp.com/
 
-# 趣味
-- よさこい
+# Hobbies / 趣味
+- Yosakoi / よさこい
+
+I belong to a team where I have friends. I've been doing it since university — 11 years now.
 
 知人がいるチームに所属しています。  
 大学時代から続けているので、11年目です。
 
-- LT
-- 勉強会
+- LT (Lightning Talks) / LT
+- Study sessions / 勉強会
   
+I love going to study sessions.
+Before COVID, I attended an offline meetup every two weeks.
+Now that online events are more common, I watch 2–3 per week.
+
 勉強会に行くことが大好きです。  
 コロナ前は2週間に1回のペースでオフラインの勉強会で行ってました。  
 現在は、オンライン勉強会が増えているので、1週間のうち2~3回視聴しています。
@@ -128,7 +163,7 @@ https://leetcode.com/hirotoKirimaru/
 https://github.com/hirotoKirimaru/resume
 -->
 
-# 職務経歴書
+# Résumé / 職務経歴書
 
 https://github.com/hirotoKirimaru/resume2
 
@@ -143,10 +178,10 @@ https://github.com/hirotoKirimaru/resume2
 
 Here are some ideas to get you started:
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
+- 🔭 I'm currently working on ...
+- 🌱 I'm currently learning ...
+- 👯 I'm looking to collaborate on ...
+- 🤔 I'm looking for help with ...
 - 💬 Ask me about ...
 - 📫 How to reach me: ...
 - 😄 Pronouns: ...


### PR DESCRIPTION
## Summary
- README.md の各セクションに英語訳を追加し、英日併記の構成に変更
- 既存の日本語テキストはそのまま残し、英語版を並べて記載
- 見出しは `English / 日本語` の形式に統一

## Test plan
- [ ] README.md のプレビューで英日双方が崩れずに表示されることを確認
- [ ] GitHub プロフィールでの見た目を確認

https://claude.ai/code/session_01MvAp2RnEYj688gdvtCMahZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvAp2RnEYj688gdvtCMahZ)_